### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+GPUCV_2022_EGSR/Library/*
+GPUCV_2022_EGSR/Temp/*
+GPUCV_2022_EGSR/Logs/*
+GPUCV_2022_EGSR/UserSettings/*


### PR DESCRIPTION
The existing gitignore assumed the Unity project was the root of the repo. But yours isn't (it would be better if it was - but this was a quicker fix)